### PR TITLE
Cambio la forma de mostrar los pictogramas

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -143,9 +143,11 @@ textarea {
 }
 
 #pictogramas ul {
-    display: flex;
+    display: grid;
+    grid-auto-flow: row;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(2, 1fr);
     width: 100%;
-    overflow: scroll;
     scroll-snap-type: x mandatory;
 }
 


### PR DESCRIPTION
En vez de que los pictogramas se muestren como row , ahora se muestran como column donde es responsive y se puede ver todos los iconos scrolleando hacia abajo.

Ignorar mis commit anteriores ( fueron eliminados , tuve un problema con github desktop)
Saludos